### PR TITLE
FIX/FEAT: Add refresh button and auto refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medusa-variant-images",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A variant images plugin for Medusa V2.",
   "author": "Betanoir",
   "repository": {

--- a/src/admin/VariantImages/VariantsImagesModal.tsx
+++ b/src/admin/VariantImages/VariantsImagesModal.tsx
@@ -82,8 +82,6 @@ const VariantsImagesModal = ({ variant, open, onClose, product, type, settings, 
     try {
       preppedImages = await prepareImages(data.media.images);
     } catch (error) {
-      console.log(error);
-
       notify.error('Error', { description: 'Something went wrong while trying to upload images.' });
       console.error('Something went wrong while trying to upload images.');
       return;
@@ -155,7 +153,10 @@ const VariantsImagesModal = ({ variant, open, onClose, product, type, settings, 
 
   return (
     <FocusModal open={open} onOpenChange={onReset} modal>
-      <FocusModal.Content>
+      <FocusModal.Content aria-describedby={undefined}>
+        <FocusModal.Title asChild>
+          <h2 className='sr-only'>Variant Images</h2>
+        </FocusModal.Title>
         <FocusModal.Header>
           <Button variant='primary' type='submit' disabled={!isDirty} isLoading={isUpdating} form='variant-images-form'>
             Save and close

--- a/src/admin/VariantImages/ViewImagesModal.tsx
+++ b/src/admin/VariantImages/ViewImagesModal.tsx
@@ -9,7 +9,7 @@ export default function ViewImagesModal({ variantThumbnail, variantImages }: { v
           <p className='text-sm'>+{variantImages.length - 2} more</p>
         </button>
       </Drawer.Trigger>
-      <Drawer.Content>
+      <Drawer.Content aria-describedby={undefined}>
         <Drawer.Header>
           <Drawer.Title>View Variant Images</Drawer.Title>
         </Drawer.Header>

--- a/src/admin/VariantImages/WidgetSettingsModal.tsx
+++ b/src/admin/VariantImages/WidgetSettingsModal.tsx
@@ -66,7 +66,7 @@ export default function WidgetSettingsModal({
           <EllipsisHorizontal />
         </Button>
       </Drawer.Trigger>
-      <Drawer.Content>
+      <Drawer.Content aria-describedby={undefined}>
         <Drawer.Header>
           <Drawer.Title>Variant Images Settings</Drawer.Title>
         </Drawer.Header>
@@ -76,11 +76,7 @@ export default function WidgetSettingsModal({
               <Heading level='h3'>Upload by option</Heading>
               {!!settings.baseOptionUpload.option && (
                 <>
-                  <Switch
-                    id='enable-option-setting'
-                    checked={enabled}
-                    onCheckedChange={handleCheckedChange}
-                  />
+                  <Switch id='enable-option-setting' checked={enabled} onCheckedChange={handleCheckedChange} />
                   <label htmlFor='enable-option-setting' className='sr-only'>
                     Enable/Disable base option
                   </label>
@@ -88,32 +84,18 @@ export default function WidgetSettingsModal({
               )}
             </div>
             <p className='text-sm text-ui-fg-muted'>
-              Instead of uploading images to each individual variant, upload to
-              multiple using a base option. Each variant with the same option
-              value will be updated.
+              Instead of uploading images to each individual variant, upload to multiple using a base option. Each variant with the same option value will be
+              updated.
             </p>
 
             <div>
               {!!settings.baseOptionUpload.option && (
-                <label
-                  htmlFor='option-select'
-                  className='text-xs text-neutral-300 block mt-2'
-                >
+                <label htmlFor='option-select' className='text-xs text-neutral-300 block mt-2'>
                   Select an option
                 </label>
               )}
-              <Select
-                size='small'
-                onValueChange={handleOptionChange}
-                value={option}
-              >
-                <Select.Trigger
-                  id='option-select'
-                  className={clx(
-                    'w-56 mt-2',
-                    !!settings.baseOptionUpload.option && 'mt-1'
-                  )}
-                >
+              <Select size='small' onValueChange={handleOptionChange} value={option}>
+                <Select.Trigger id='option-select' className={clx('w-56 mt-2', !!settings.baseOptionUpload.option && 'mt-1')}>
                   <Select.Value placeholder='Select Option' />
                 </Select.Trigger>
                 <Select.Content>
@@ -128,11 +110,8 @@ export default function WidgetSettingsModal({
 
             {option && (
               <p className='text-xs text-ui-fg-muted font-semibold'>
-                All variants with the same value for the{' '}
-                <span className='text-ui-fg-interactive'>
-                  {options?.find((o) => o.id === option)?.title}
-                </span>{' '}
-                option will be updated simultaneously
+                All variants with the same value for the <span className='text-ui-fg-interactive'>{options?.find((o) => o.id === option)?.title}</span> option
+                will be updated simultaneously
               </p>
             )}
           </div>

--- a/src/admin/VariantImages/hooks/useTimer.ts
+++ b/src/admin/VariantImages/hooks/useTimer.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+type TimerProps = {
+  every?: number;
+  length?: number;
+  onComplete?: () => void;
+  recursive?: boolean;
+};
+
+export const useTimer = ({ every = 1e3, length = 3e5, onComplete = () => null, recursive = false }: TimerProps) => {
+  const [timeLeft, setTimeLeft] = useState(length);
+  const [isRunning, setRunning] = useState(true);
+
+  let countdown: NodeJS.Timeout;
+  let timeout: NodeJS.Timeout;
+
+  const handleStop = (restartTimer = false) => {
+    setRunning(false);
+    clearInterval(countdown);
+
+    if (restartTimer) setTimeLeft(length);
+
+    onComplete();
+  };
+
+  useEffect(() => {
+    if (!isRunning)
+      if (recursive) timeout = setTimeout(() => setRunning(true), 3000);
+      else return;
+
+    countdown = setInterval(() => {
+      setTimeLeft((prevTime) => {
+        if (prevTime <= 0) {
+          handleStop();
+          return timeLeft;
+        }
+
+        return prevTime - every;
+      });
+    }, every);
+
+    return () => {
+      clearInterval(countdown);
+      clearTimeout(timeout);
+    };
+  }, [isRunning]);
+
+  const secondsLeft = Math.ceil(timeLeft / 1000);
+
+  return { timeLeft: secondsLeft, fetching: !isRunning, restart: handleStop.bind(null, true) };
+};

--- a/src/admin/VariantImages/utils/images.ts
+++ b/src/admin/VariantImages/utils/images.ts
@@ -35,7 +35,7 @@ export const prepareImages = async (images: FormImage[]) => {
     });
 
     const res = await fetchBackend('/admin/uploads', { body: form, method: 'POST', files: true }).catch((err: any) => console.log(err));
-    if (res) console.log(res);
+
     if (res) uploadedImgs = res.files;
   }
 

--- a/src/admin/VariantImages/utils/util.ts
+++ b/src/admin/VariantImages/utils/util.ts
@@ -55,20 +55,12 @@ export const fetchBackend = async (url: string, options: OptionArgs = {}) => {
   const optionsObj: RequestInit = {
     credentials: 'include',
     method: options.method || 'GET',
-
-    // headers: {
-    //   'Content-Type': options.files ? 'multipart/form-data' : 'application/json',
-    // },
   };
 
   if (!options.files)
     optionsObj.headers = {
       'Content-Type': 'application/json',
     };
-
-  // if (options.files) {
-  //   (optionsObj.headers as Record<string, string>)['enctype'] = 'multipart/form-data';
-  // }
 
   if (options.body) {
     if (options.files) optionsObj.body = options.body as BodyInit;


### PR DESCRIPTION
Added a feature that automatically refreshes the stored information for the plugin every 60 seconds. You may also click the refresh button.

Unfortunately, I can't find a way for it to automatically update as soon as you add an image or variant, for example. This is the best way I see it, as it is still user-friendly.

If you add an image via the product images, you will see the update; however, if you add an image via the variant images, you will not see an update in the product images until you refresh the page.

Likewise, if you create a new variant, the plugin will automatically refresh and show the new variant, or you can click the refresh button.

This resolves #4 