### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,28 +55,27 @@
     "vite": "^5.2.11",
     "yalc": "^1.0.0-pre.53"
   },
+  "dependencies": {
+    "lodash-es": "^4.17.21"
+  },
   "peerDependencies": {
-    "@medusajs/admin-sdk": "2.4.0",
-    "@medusajs/cli": "2.4.0",
-    "@medusajs/framework": "2.4.0",
-    "@medusajs/icons": "2.4.0",
-    "@medusajs/js-sdk": "2.4.0",
-    "@medusajs/medusa": "2.4.0",
-    "@medusajs/test-utils": "2.4.0",
-    "@medusajs/ui": "4.0.3",
-    "@mikro-orm/cli": "6.4.3",
-    "@mikro-orm/core": "6.4.3",
-    "@mikro-orm/knex": "6.4.3",
-    "@mikro-orm/migrations": "6.4.3",
-    "@mikro-orm/postgresql": "6.4.3",
+    "@medusajs/admin-sdk": "^2.4.0",
+    "@medusajs/cli": "^2.4.0",
+    "@medusajs/framework": "^2.4.0",
+    "@medusajs/icons": "^2.4.0",
+    "@medusajs/js-sdk": "^2.4.0",
+    "@medusajs/medusa": "^2.4.0",
+    "@medusajs/test-utils": "^2.4.0",
+    "@medusajs/ui": "^4.0.3",
+    "@mikro-orm/cli": "^6.4.3",
+    "@mikro-orm/core": "^6.4.3",
+    "@mikro-orm/knex": "^6.4.3",
+    "@mikro-orm/migrations": "^6.4.3",
+    "@mikro-orm/postgresql": "^6.4.3",
     "awilix": "^8.0.1",
-    "pg": "^8.13.0",
-    "qs": "^6.12.0"
+    "pg": "^8.13.0"
   },
   "engines": {
     "node": ">=20"
-  },
-  "dependencies": {
-    "lodash-es": "^4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medusa-variant-images",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A variant images plugin for Medusa V2.",
   "author": "Betanoir",
   "repository": {


### PR DESCRIPTION
Fixed an issue with the peer dependencies requiring the exact version `2.4.0` in Medusa packages. They now require between `2.4.0` and `2.5.0`